### PR TITLE
Add bower.json to make available on Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "underscore.string": "*",
     "moment": "2.0.0",
     "lodash": "1.2.1",
-    "numeral": "1.4.8",
+    "numeral": "1.5.0",
     "numericjs": "1.2.6",
     "rm-jstat": "*"
   },


### PR DESCRIPTION
I have needed to do things in suboptimal ways such as add my own repo of jstat onto bower and leave out financial.js (as it seems to be node-only?) but these things can be improved. What matters is that with this patch, formula.js can be registered onto bower and become easily available to lots of web devs who like their front end packages tidy :)
