### PR TITLE
make SUM support multi dimensional arrays

### DIFF
--- a/lib/formula.js
+++ b/lib/formula.js
@@ -4027,7 +4027,13 @@
       for (var i = 0; i < numbers.length; i++) {
         if (numbers[i] instanceof Array) {
           for (var j = 0; j < numbers[i].length; j++) {
-            result += (Formula.ISNUMBER(numbers[i][j])) ? numbers[i][j] : 0;
+            if (numbers[i][j] instanceof Array) {
+              for (var k = 0; k < numbers[i][j].length; k++) {
+                result += (Formula.ISNUMBER(numbers[i][j][k])) ? numbers[i][j][k] : 0;
+              }
+            } else {
+              result += (Formula.ISNUMBER(numbers[i][j])) ? numbers[i][j] : 0;
+            }
           }
         } else {
           result += (Formula.ISNUMBER(numbers[i])) ? numbers[i] : 0;

--- a/public/tests.js
+++ b/public/tests.js
@@ -1204,6 +1204,7 @@
         {"call": "SUM([1, 2, 3])", "result": 6},
         {"call": "SUM([1, 2, 3], 1, 2)", "result": 9},
         {"call": "SUM([1, 2, 3], [1, 2])", "result": 9},
+        {"call": "SUM([[1,1], [2,2], [3,3]])", "result": 12},
       ]},
       {"function": "SUBSTITUTE", "tests": [
         {"call": "SUBSTITUTE('Jim Alateras', 'im', 'ames')", "result": 'James Alateras'},


### PR DESCRIPTION
As of now, `SUM(A1:A3)` could be translated as `SUM([A1, A2, A3])` and that works, but if you SUM a range that spreads for multiple lines and columns, like `SUM(A1:B3)`, that would be translated to `SUM([[A1,B1], [A2, B2], [A3, B3]])` and that wouldn't work.

This PR makes that work.
