### PR TITLE
#NUM! when POWER has a negative base and fractional exponent

### DIFF
--- a/lib/formula.js
+++ b/lib/formula.js
@@ -3897,7 +3897,12 @@
     };
 
     Formula.POWER = function (number, power) {
-      return Math.pow(number, power);
+      var result = Math.pow(number, power);
+      if (isNaN(result)) {
+        return '#NUM!';
+      }
+
+      return result;
     };
 
     Formula.PRODUCT = function () {

--- a/public/tests.js
+++ b/public/tests.js
@@ -1244,6 +1244,10 @@
         {"call": "FINV(1, 10, 22)", "result": 0},
         {"call": "FINV(-0.1, 10, 22)", "result": "#NUM!"},
         {"call": "FINV(1.1, 10, 22)", "result": "#NUM!"}
+      ]},
+      {"function": "POWER", "tests": [
+        {"call": "POWER(1, 2)", "result": 2},
+        {"call": "POWER(-1, 0.5)", "result": "#NUM!"},
       ]}
     ];
 


### PR DESCRIPTION
Following the error handling style of the rest of your functions, POWER with a negative base and fractional exponent should return `'#NUM!'` instead of `NaN`.
