### PR TITLE
add error handling formulas

### DIFF
--- a/lib/formula.js
+++ b/lib/formula.js
@@ -5314,6 +5314,28 @@
     Formula.NUMERAL = function (number, format) {
       return numeral(number).format(format);
     };
+
+    // Excel Error Handling
+    Formula.ISERR = function (value) {
+      return value === '#VALUE!' ||
+        value === '#REF!' ||
+        value === '#DIV/0!' ||
+        value === '#NUM!' ||
+        value === '#NAME?' ||
+        value === '#NULL!';
+    };
+
+    Formula.ISERROR = function (value) {
+      return Formula.ISERR(value) || value === '#N/A';
+    };
+
+    Formula.IFERROR = function (value, valueIfError) {
+      if (Formula.ISERROR(value)) {
+        return valueIfError;
+      }
+
+      return value;
+    };
     return Formula;
   }
 }).call(this);


### PR DESCRIPTION
I could not find documentation for `ISERR`, but the help text in Excel says it checks for everything except `#N/A`. [`ISERROR`](http://office.microsoft.com/en-001/excel-help/iserror-function-dax-HA102838076.aspx) checks for everything `ISERR` does, plus `#N/A`. Both of them return booleans.

[`IFERROR`](http://office.microsoft.com/en-001/excel-help/iferror-function-HA001231765.aspx) returns the second argument if the first one is an error.
