### PR TITLE
Fixing SEARCH function to return error.value when text is not found

### DIFF
--- a/lib/text.js
+++ b/lib/text.js
@@ -235,11 +235,13 @@ exports.RIGHT = function(text, number) {
 };
 
 exports.SEARCH = function(find_text, within_text, position) {
+  var foundAt;
   if (typeof find_text !== 'string' || typeof within_text !== 'string') {
     return error.value;
   }
   position = (position === undefined) ? 0 : position;
-  return within_text.toLowerCase().indexOf(find_text.toLowerCase(), position - 1) + 1;
+  foundAt = within_text.toLowerCase().indexOf(find_text.toLowerCase(), position - 1);
+  return (foundAt === -1)?error.value:foundAt; 
 };
 
 exports.SPLIT = function (text, separator) {


### PR DESCRIPTION
When I look at the MS documentation it says that:

If the value of find_text is not found, the #VALUE! error value is returned.

http://office.microsoft.com/en-001/excel-help/search-searchb-functions-HP010062577.aspx

A common trick is to use ISNUMBER(SEARCH("foo", "barbar")) which should return FALSE.
