### PR TITLE
Fixed issue #40: BETADIST function does not work correctly.

### DIFF
--- a/lib/statistical.js
+++ b/lib/statistical.js
@@ -98,6 +98,10 @@ exports.AVERAGEIFS = function() {
 exports.BETA = {};
 
 exports.BETA.DIST = function(x, alpha, beta, cumulative, A, B) {
+  if (arguments.length < 4) {
+    return error.value;
+  }
+
   A = (A === undefined) ? 0 : A;
   B = (B === undefined) ? 1 : B;
 

--- a/test/statistical.js
+++ b/test/statistical.js
@@ -59,7 +59,10 @@ suite('Statistical', function() {
   });
 
   test('BETA.DIST', function() {
-    statistical.BETA.DIST(2, 8, 10, 1, 3).should.approximately(0.6854705810117458, 1e-9);
+    statistical.BETA.DIST(2, 8, 10, true, 1, 3).should.approximately(0.6854705810117458, 1e-9);
+    statistical.BETA.DIST(1/52, 0.4, 9.6, false).should.approximately(9.966606842186748, 1e-9);
+    statistical.BETA.DIST(1/52, 0.4, 9.6, true).should.approximately(0.5406016379941343, 1e-9);
+    statistical.BETA.DIST(2, 8, 10).should.equal(error.value);
     statistical.BETA.DIST(2, 8, 'invalid', 1, 3).should.equal(error.value);
   });
 


### PR DESCRIPTION
Issue:

Following latest MS Excel documentation: [BETA.DIST](https://support.office.com/en-my/article/BETA-DIST-function-11188c9c-780a-42c7-ba43-9ecb5a878d31?ui=en-US&rs=en-MY&ad=MY&fromAR=1) will take at least four arguments.

Solution:

Added argument checks in function BETA.DIST().
More tests are also added.