### PR TITLE
fixed a bug in MID function - substring was incorrectly used

### DIFF
--- a/lib/text.js
+++ b/lib/text.js
@@ -155,7 +155,9 @@ exports.MID = function(text, start, number) {
   if (utils.anyIsError(start, number) || typeof text !== 'string') {
     return number;
   }
-  return text.substring(start - 1, number);
+  begin = start - 1
+  end = begin + number
+  return text.substring(begin, end);
 };
 
 // TODO
@@ -241,7 +243,7 @@ exports.SEARCH = function(find_text, within_text, position) {
   }
   position = (position === undefined) ? 0 : position;
   foundAt = within_text.toLowerCase().indexOf(find_text.toLowerCase(), position - 1)+1;
-  return (foundAt === 0)?error.value:foundAt; 
+  return (foundAt === 0)?error.value:foundAt;
 };
 
 exports.SPLIT = function (text, separator) {


### PR DESCRIPTION
The signature of substring is text.substring(begin, end), as opposed to MID(text, start, numberOfCharsToReturn).