### PR TITLE
Fix base 10 as default for LOG function

### DIFF
--- a/lib/math-trig.js
+++ b/lib/math-trig.js
@@ -452,11 +452,12 @@ exports.LN = function(number) {
 
 exports.LOG = function(number, base) {
   number = utils.parseNumber(number);
-  base = utils.parseNumber(base);
+  base = (base === undefined) ? 10 : utils.parseNumber(base);
+
   if (utils.anyIsError(number, base)) {
     return error.value;
   }
-  base = (base === undefined) ? 10 : base;
+
   return Math.log(number) / Math.log(base);
 };
 

--- a/test/math-trig.js
+++ b/test/math-trig.js
@@ -333,6 +333,7 @@ suite('Math & Trig', function() {
   });
 
   test('LOG', function() {
+    mathTrig.LOG(10).should.equal(1);
     mathTrig.LOG(10, 10).should.equal(1);
     mathTrig.LOG(10, 'invalid').should.equal(error.value);
   });


### PR DESCRIPTION
According to Excel documentation LOG should be calculated with base 10 if omitted.

https://support.office.com/en-us/article/LOG-function-4E82F196-1CA9-4747-8FB0-6C4A3ABB3280

This feature was already implemented but was not correctly working.

Can you please create a minor release afterward to have an update of the CDN?