### PR TITLE
Update math-trig.js FLOOR function

### DIFF
--- a/lib/math-trig.js
+++ b/lib/math-trig.js
@@ -346,7 +346,7 @@ exports.FLOOR = function(number, significance) {
   if (number >= 0) {
     return exports.ROUND(Math.floor(number / significance) * significance, precision);
   } else {
-    return -exports.ROUND(Math.ceil(Math.abs(number) / significance), precision);
+    return -exports.ROUND(Math.ceil(Math.abs(number) / significance) * significance, precision);
   }
 };
 


### PR DESCRIPTION
The FLOOR function for the negative number case was not multiplying by significance after dividing by significance. That seemed inconsistent with with FLOOR.MATH and CEILING and the non-negative number case of FLOOR.