### PR TITLE
fix CEILING behavior for values of "significance" that are not powers…

### DIFF
--- a/lib/math-trig.js
+++ b/lib/math-trig.js
@@ -187,14 +187,13 @@ exports.CEILING = function(number, significance, mode) {
   if (significance === 0) {
     return 0;
   }
-  var precision = -Math.floor(Math.log(significance) / Math.log(10));
   if (number >= 0) {
-    return exports.ROUND(Math.ceil(number / significance) * significance, precision);
+    return Math.ceil(number / significance) * significance;
   } else {
     if (mode === 0) {
-      return -exports.ROUND(Math.floor(Math.abs(number) / significance) * significance, precision);
+      return -1 * Math.floor(Math.abs(number) / significance) * significance;
     } else {
-      return -exports.ROUND(Math.ceil(Math.abs(number) / significance) * significance, precision);
+      return -1 * Math.ceil(Math.abs(number) / significance) * significance;
     }
   }
 };

--- a/test/math-trig.js
+++ b/test/math-trig.js
@@ -117,6 +117,10 @@ suite('Math & Trig', function() {
     mathTrig.CEILING(-4.1, 2, -1).should.equal(-6);
     mathTrig.CEILING(-4.1, -2, 0).should.equal(-4);
     mathTrig.CEILING(-4.1, -2, -1).should.equal(-6);
+    mathTrig.CEILING(0.19, 0.25, 0).should.equal(0.25);
+    mathTrig.CEILING(0.39, 0.25, 0).should.equal(0.5);
+    mathTrig.CEILING(0.69, 0.25, 0).should.equal(0.75);
+    mathTrig.CEILING(0.89, 0.25, 0).should.equal(1);
     mathTrig.CEILING(-4.1, -2, 'invalid').should.equal(error.value);
   });
 


### PR DESCRIPTION
… of 10

previously, the implementation of CEILING would return 0.3 for CEILING(0.19, 0.25), and 0.8 for CEILING(0.69, 0.25), due to the rounding logic, which doesn't work when `significance` is not a power of 10.

Google Sheets's implementation does this correctly, and even calls it out explicitly that they handle this:

> CEILING is most often used with factor set to a 'round' number such as 0.1 or 0.01 in order to round to a particular decimal place. However, factor can, in fact, be any number of the same sign as value, e.g. CEILING(23.25,0.18) which results in 23.4, which is 0.18 * 130. This can be used, for instance, to round up to a particular denomination of currency (e.g. 0.25 or 0.05 USD).

(see https://support.google.com/docs/answer/3093471?hl=en)