### PR TITLE
fix FLOOR behavior for values of "significance" that are not powers o…

### DIFF
--- a/lib/math-trig.js
+++ b/lib/math-trig.js
@@ -175,8 +175,8 @@ exports.BASE = function(number, radix, min_length) {
 };
 
 exports.CEILING = function(number, significance, mode) {
-  significance = (significance === undefined) ? 1 : Math.abs(significance);
-  mode = mode || 0;
+  significance = (significance === undefined) ? 1 : significance;
+  mode = (mode === undefined) ? 0 : mode;
 
   number = utils.parseNumber(number);
   significance = utils.parseNumber(significance);
@@ -187,6 +187,8 @@ exports.CEILING = function(number, significance, mode) {
   if (significance === 0) {
     return 0;
   }
+
+  significance = Math.abs(significance);
   if (number >= 0) {
     return Math.ceil(number / significance) * significance;
   } else {
@@ -326,31 +328,7 @@ exports.FACTDOUBLE = function(number) {
   }
 };
 
-exports.FLOOR = function(number, significance) {
-  number = utils.parseNumber(number);
-  significance = utils.parseNumber(significance);
-  if (utils.anyIsError(number, significance)) {
-    return error.value;
-  }
-  if (significance === 0) {
-    return 0;
-  }
-
-  if (!(number > 0 && significance > 0) && !(number < 0 && significance < 0)) {
-    return error.num;
-  }
-
-  significance = Math.abs(significance);
-  var precision = -Math.floor(Math.log(significance) / Math.log(10));
-  if (number >= 0) {
-    return exports.ROUND(Math.floor(number / significance) * significance, precision);
-  } else {
-    return -exports.ROUND(Math.ceil(Math.abs(number) / significance), precision);
-  }
-};
-
-//TODO: Verify
-exports.FLOOR.MATH = function(number, significance, mode) {
+exports.FLOOR = function(number, significance, mode) {
   significance = (significance === undefined) ? 1 : significance;
   mode = (mode === undefined) ? 0 : mode;
 
@@ -364,15 +342,19 @@ exports.FLOOR.MATH = function(number, significance, mode) {
     return 0;
   }
 
-  significance = significance ? Math.abs(significance) : 1;
-  var precision = -Math.floor(Math.log(significance) / Math.log(10));
+  significance = Math.abs(significance);
   if (number >= 0) {
-    return exports.ROUND(Math.floor(number / significance) * significance, precision);
-  } else if (mode === 0 || mode === undefined) {
-    return -exports.ROUND(Math.ceil(Math.abs(number) / significance) * significance, precision);
+    return Math.floor(number / significance) * significance;
+  } else {
+    if (mode === 0) {
+      return -1 * Math.ceil(Math.abs(number) / significance) * significance;
+    } else {
+      return -1 * Math.floor(Math.abs(number) / significance) * significance;
+    }
   }
-  return -exports.ROUND(Math.floor(Math.abs(number) / significance) * significance, precision);
 };
+
+exports.FLOOR.MATH = exports.FLOOR;
 
 // Deprecated
 exports.FLOOR.PRECISE = exports.FLOOR.MATH;

--- a/test/math-trig.js
+++ b/test/math-trig.js
@@ -256,39 +256,47 @@ suite('Math & Trig', function() {
   });
 
   test('FLOOR', function() {
-    mathTrig.FLOOR(3.7, 2).should.equal(2);
-    mathTrig.FLOOR(-2.5, -2).should.equal(-2);
-    mathTrig.FLOOR(2.5, -2).should.equal(error.num);
-    mathTrig.FLOOR(1.58, 0.1).should.approximately(1.5, 1e-9);
-    mathTrig.FLOOR(0.234, 0.01).should.approximately(0.23, 1e-9);
-    mathTrig.FLOOR(0.234, 0).should.equal(0);
-    mathTrig.FLOOR('invalid', 0).should.equal(error.value);
-  });
-
-  test('FLOOR.PRECISE', function() {
-    mathTrig.FLOOR.PRECISE(2014.6, 0.2).should.equal(2014.4);
-    mathTrig.FLOOR.PRECISE(-3.2,-1).should.equal(-4);
-    mathTrig.FLOOR.PRECISE(3.2,1).should.equal(3);
-    mathTrig.FLOOR.PRECISE(-3.2,1).should.equal(-4);
-    mathTrig.FLOOR.PRECISE(3.2,-1).should.equal(3);
-    mathTrig.FLOOR.PRECISE(3.2).should.equal(3);
+    mathTrig.FLOOR(4.1).should.equal(4);
+    mathTrig.FLOOR(4.9).should.equal(4);
+    mathTrig.FLOOR(-4.1).should.equal(-5);
+    mathTrig.FLOOR(-4.9).should.equal(-5);
+    mathTrig.FLOOR(4.1, 0).should.equal(0);
+    mathTrig.FLOOR(4.1, 1).should.equal(4);
+    mathTrig.FLOOR(4.1, 2).should.equal(4);
+    mathTrig.FLOOR(-4.1, 2).should.equal(-6);
+    mathTrig.FLOOR(-4.1, -2).should.equal(-6);
+    mathTrig.FLOOR(1.234, 0.1).should.approximately(1.2, 1e-9);
+    mathTrig.FLOOR(-1.234, 0.1).should.approximately(-1.3, 1e-9);
+    mathTrig.FLOOR(-1.234, -0.1).should.approximately(-1.3, 1e-9);
+    mathTrig.FLOOR(-1.234, -0.01).should.approximately(-1.24, 1e-9);
+    mathTrig.FLOOR(-1.234, -0.001).should.approximately(-1.234, 1e-9);
+    mathTrig.FLOOR(-4.1, 2, 0).should.equal(-6);
+    mathTrig.FLOOR(-4.1, 2, -1).should.equal(-4);
+    mathTrig.FLOOR(-4.1, -2, 0).should.equal(-6);
+    mathTrig.FLOOR(-4.1, -2, -1).should.equal(-4);
+    mathTrig.FLOOR(0.19, 0.25, 0).should.equal(0);
+    mathTrig.FLOOR(0.39, 0.25, 0).should.equal(0.25);
+    mathTrig.FLOOR(0.69, 0.25, 0).should.equal(0.5);
+    mathTrig.FLOOR(0.89, 0.25, 0).should.equal(0.75);
+    mathTrig.FLOOR(-4.1, -2, 'invalid').should.equal(error.value);
   });
 
   test('FLOOR.MATH', function() {
     mathTrig.FLOOR.MATH(24.3, 5).should.equal(20);
     mathTrig.FLOOR.MATH(6.7).should.equal(6);
     mathTrig.FLOOR.MATH(-8.1, 2).should.equal(-10);
-    mathTrig.FLOOR.MATH(-8.1, 0).should.equal(0);
     mathTrig.FLOOR.MATH(-5.5, 2, -1).should.equal(-4);
-    mathTrig.FLOOR.MATH('invalid', 0).should.equal(error.value);
+    mathTrig.FLOOR.MATH(-5.5, 2, 'invalid').should.equal(error.value);
+  });
 
-    mathTrig.FLOOR.MATH(-3.2, -1).should.equal(-4);
-    mathTrig.FLOOR.MATH(3.2, 1).should.equal(3);
-    mathTrig.FLOOR.MATH(-3.2, 1).should.equal(-4);
-    mathTrig.FLOOR.MATH(3.2, -1).should.equal(3);
-    mathTrig.FLOOR.MATH(3.2).should.equal(3);
-    mathTrig.FLOOR.MATH(3.2, 0).should.equal(0);
-    mathTrig.FLOOR.MATH(3.2, 'invalid').should.equal(error.value);
+  test('FLOOR.PRECISE', function() {
+    mathTrig.FLOOR.PRECISE(4.3).should.equal(4);
+    mathTrig.FLOOR.PRECISE(-4.3).should.equal(-5);
+    mathTrig.FLOOR.PRECISE(4.3, 2).should.equal(4);
+    mathTrig.FLOOR.PRECISE(4.3, -2).should.equal(4);
+    mathTrig.FLOOR.PRECISE(-4.3, 2).should.equal(-6);
+    mathTrig.FLOOR.PRECISE(-4.3, -2).should.equal(-6);
+    mathTrig.FLOOR.PRECISE(-4.3, 'invalid').should.equal(error.value);
   });
 
   test('GCD', function() {


### PR DESCRIPTION
…f 10

https://github.com/sutoiku/formula.js/pull/63 fixed a bug in CEILING. I realized FLOOR has the same problem. this PR fixes it

some code cleanliness changes, in addition:
- CEILING implementation changes
  - move the Math.abs(significance) call to after we've actually parsed it as a number and checked for errors
  - use `mode = (mode === undefined) ? 0 : mode` instead of `mode || 0` since checking truthiness of numbers is kind of an antipattern
- FLOOR implementation changes
  - remove the check `!(number > 0 && significance > 0) && !(number < 0 && significance < 0)` for consistency for CEILING, which just silently takes the absolute value of significance
  - use `exports.FLOOR.MATH = exports.FLOOR` to be consistent with CEILING.MATH
  - remove `mode === undefined` check after we've already parsed it as number
- change the ordering of FLOOR/FLOOR.MATH/FLOOR.PRECISE tests to be consistent with the analogous CEILING tests