### PR TITLE
SUBSTITUTE bugfix

### DIFF
--- a/lib/text.js
+++ b/lib/text.js
@@ -253,7 +253,7 @@ exports.SPLIT = function (text, separator) {
 };
 
 exports.SUBSTITUTE = function(text, old_text, new_text, occurrence) {
-  if (!text || !old_text || !new_text) {
+  if (!text || !old_text || (!new_text && new_text !== '')) {
     return text;
   } else if (occurrence === undefined) {
     return text.replace(new RegExp(old_text, 'g'), new_text);

--- a/test/text.js
+++ b/test/text.js
@@ -176,6 +176,7 @@ suite('Text', function() {
     text.SUBSTITUTE('', 'im', 'ames').should.equal("");
     should.not.exist(text.SUBSTITUTE(undefined, 'im', 'ames'));
     text.SUBSTITUTE('Quarter 1, 2008', '1', '2', 1).should.equal('Quarter 2, 2008');
+    text.SUBSTITUTE('t:07792 526879', 't:', '').should.equal('07792 526879');
   });
 
   test('T', function() {


### PR DESCRIPTION
The `SUBSTITUTE` function wasn't able to replace text with a blank string, as it does in Excel. Fix added with a test case.